### PR TITLE
Resolve some build errors on Linux + GCC 10

### DIFF
--- a/Source/AllProjects/CIDBuild/Linux/CIDBuild_FindInfo_Linux.cpp
+++ b/Source/AllProjects/CIDBuild/Linux/CIDBuild_FindInfo_Linux.cpp
@@ -173,4 +173,9 @@ TFindInfo::SetFromHostInfo( const   tCIDLib::TVoid* const   pHostFindBuf
     //  any platform can represent its time easily in a common format.
     //
     m_tmLastWrite = double(pFileInfo->StatBuf.st_mtime);
+
+    if (S_ISDIR(pFileInfo->StatBuf.st_mode))
+        m_bIsDir = kCIDLib::True;
+    else
+        m_bIsDir = kCIDLib::False;
 }

--- a/Source/AllProjects/CIDKernel/Linux/CIDKernel_PlatformDefines.hpp
+++ b/Source/AllProjects/CIDKernel/Linux/CIDKernel_PlatformDefines.hpp
@@ -110,3 +110,8 @@ int main(int argc, char** argv) \
 #define CID_DEBUG_OFF       1
 #endif
 
+// ---------------------------------------------------------------------------
+//  Suppress a single line MSVC warning - since MSVC is not used on Linux,
+//  this does nothing here.
+// ---------------------------------------------------------------------------
+#define CIDLib_Suppress(wid)

--- a/Source/AllProjects/CIDKernel/Linux/CIDKernel_SystemInfo_Linux.cpp
+++ b/Source/AllProjects/CIDKernel/Linux/CIDKernel_SystemInfo_Linux.cpp
@@ -415,7 +415,7 @@ TCIDKrnlModule::bInitTermSysInfo(const tCIDLib::EInitTerm eInitTerm)
 // ---------------------------------------------------------------------------
 tCIDLib::TBoolean
 TKrnlSysInfo::bCmdLineArg(  const   tCIDLib::TCard4 c4Index
-                            , const tCIDLib::TCh*&  pszToFill)
+                            ,       TKrnlString&    kstrToFill)
 {
     if (CIDKernel_SystemInfo_Linux::argc != -1)
         CIDKernel_SystemInfo_Linux::InitArgArray();
@@ -425,7 +425,7 @@ TKrnlSysInfo::bCmdLineArg(  const   tCIDLib::TCard4 c4Index
         TKrnlError::SetLastKrnlError(kKrnlErrs::errcGen_IndexError);
         return kCIDLib::False;
     }
-    pszToFill = CIDKernel_SystemInfo_Linux::CachedInfo.apszArgList[c4Index];
+    kstrToFill = CIDKernel_SystemInfo_Linux::CachedInfo.apszArgList[c4Index];
     return kCIDLib::True;
 }
 
@@ -456,8 +456,7 @@ TKrnlSysInfo::bQueryMachineID(          tCIDLib::TCh* const pchBuffer
 
 
 tCIDLib::TBoolean
-TKrnlSysInfo::bQuerySpecialPath(        tCIDLib::TCh* const     pszBuffer
-                                , const tCIDLib::TCard4         c4MaxChars
+TKrnlSysInfo::bQuerySpecialPath(        TKrnlString&            kstrToFill
                                 , const tCIDLib::ESpecialPaths  ePath)
 {
     // <TBD> Figure this out
@@ -468,8 +467,7 @@ TKrnlSysInfo::bQuerySpecialPath(        tCIDLib::TCh* const     pszBuffer
 
 
 tCIDLib::TBoolean
-TKrnlSysInfo::bQueryUserName(       tCIDLib::TCh* const pszBuffer
-                            , const tCIDLib::TCard4     c4MaxChars)
+TKrnlSysInfo::bQueryUserName(TKrnlString& kstrToFill)
 {
     struct passwd* pwd = ::getpwuid(::getuid());
 
@@ -479,13 +477,7 @@ TKrnlSysInfo::bQueryUserName(       tCIDLib::TCh* const pszBuffer
         return kCIDLib::False;
     }
 
-    if (c4MaxChars < ::strlen(pwd->pw_name))
-    {
-        TKrnlError::SetLastKrnlError(kKrnlErrs::errcData_InsufficientBuffer);
-        return kCIDLib::False;
-    }
-
-    TRawStr::pszConvert(pwd->pw_name, pszBuffer, c4MaxChars);
+    kstrToFill = pwd->pw_name;
 
     return kCIDLib::True;
 }


### PR DESCRIPTION
This resolves some errors I got while trying to run CIDBuild.  All the changes are fairly small but as a side-effect, I implemented TFindInfo::m_bIsDir for Linux, because without it, CIDBuild would fail after its first run, saying it could not create the AppIcons and AppImages directories in Output once they already existed.  With these changes I am able to build CIDKernel, although I still get errors trying to build the CIDLib project.